### PR TITLE
installer: set hardware clock to UTC

### DIFF
--- a/preseed_files/installer.cfg
+++ b/preseed_files/installer.cfg
@@ -61,5 +61,5 @@ d-i apt-setup/volatile_host string volatile.debian.org
 
 # clock
 # time/zone in early_script
-d-i	clock-setup/utc	boolean	false
+d-i	clock-setup/utc	boolean	true
 d-i	clock-setup/ntp boolean true


### PR DESCRIPTION
Why:

* Debian expects the hardware clock to be UTC